### PR TITLE
Updated SkiaSharp (fixes read for some SVG files)

### DIFF
--- a/Resizetizer.Tests/Resizetizer.Tests.csproj
+++ b/Resizetizer.Tests/Resizetizer.Tests.csproj
@@ -37,11 +37,12 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.2-beta2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SkiaSharp">
-      <HintPath>..\packages\SkiaSharp.1.56.1\lib\net45\SkiaSharp.dll</HintPath>
+      <HintPath>..\packages\SkiaSharp.1.60.2\lib\net45\SkiaSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SkiaSharp.Svg">
-      <HintPath>..\packages\SkiaSharp.Svg.1.56.1\lib\portable-net45+win8+wpa81+wp8\SkiaSharp.Svg.dll</HintPath>
+    <Reference Include="SkiaSharp.Extended.Svg">
+      <HintPath>..\packages\SkiaSharp.Svg.1.60.0\lib\portable-net45+win8+wp8+wpa81\SkiaSharp.Extended.Svg.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />
@@ -56,5 +57,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\SkiaSharp.1.56.1\build\net45\SkiaSharp.targets" Condition="Exists('..\packages\SkiaSharp.1.56.1\build\net45\SkiaSharp.targets')" />
+  <Import Project="..\packages\SkiaSharp.1.60.2\build\net45\SkiaSharp.targets" Condition="Exists('..\packages\SkiaSharp.1.60.2\build\net45\SkiaSharp.targets')" />
 </Project>

--- a/Resizetizer.Tests/packages.config
+++ b/Resizetizer.Tests/packages.config
@@ -2,7 +2,8 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.2-beta2" targetFramework="net45" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />
-  <package id="SkiaSharp" version="1.56.1" targetFramework="net45" />
-  <package id="SkiaSharp.Svg" version="1.56.1" targetFramework="net45" />
+  <package id="SkiaSharp" version="1.60.2" targetFramework="net45" />
+  <package id="SkiaSharp.Svg" version="1.60.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net45" />
   <package id="YamlDotNet" version="4.1.0" targetFramework="net45" />
 </packages>

--- a/Resizetizer/PngImageResizer.cs
+++ b/Resizetizer/PngImageResizer.cs
@@ -29,7 +29,7 @@ namespace Resizetizer
 			var newBmp = bmp.Resize(new SKImageInfo((int)(bmp.Width * adjustRatio), (int)(bmp.Height * adjustRatio)), SKBitmapResizeMethod.Box);
 
 			var img = SKImage.FromBitmap(newBmp);
-			var data = img.Encode(SKImageEncodeFormat.Png, 100);
+            var data = img.Encode(SKEncodedImageFormat.Png, 100);
 
 			using (var fs = File.Open(destinationFile, FileMode.Create))
 				data.SaveTo(fs);

--- a/Resizetizer/Resizetizer.csproj
+++ b/Resizetizer/Resizetizer.csproj
@@ -35,11 +35,12 @@
       <HintPath>..\packages\YamlDotNet.4.1.0\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
     <Reference Include="SkiaSharp">
-      <HintPath>..\packages\SkiaSharp.1.56.1\lib\net45\SkiaSharp.dll</HintPath>
+      <HintPath>..\packages\SkiaSharp.1.60.2\lib\net45\SkiaSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SkiaSharp.Svg">
-      <HintPath>..\packages\SkiaSharp.Svg.1.56.1\lib\portable-net45+win8+wpa81+wp8\SkiaSharp.Svg.dll</HintPath>
+    <Reference Include="SkiaSharp.Extended.Svg">
+      <HintPath>..\packages\SkiaSharp.Svg.1.60.0\lib\portable-net45+win8+wp8+wpa81\SkiaSharp.Extended.Svg.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ImageAsset.cs" />
@@ -58,5 +59,5 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\SkiaSharp.1.56.1\build\net45\SkiaSharp.targets" Condition="Exists('..\packages\SkiaSharp.1.56.1\build\net45\SkiaSharp.targets')" />
+  <Import Project="..\packages\SkiaSharp.1.60.2\build\net45\SkiaSharp.targets" Condition="Exists('..\packages\SkiaSharp.1.60.2\build\net45\SkiaSharp.targets')" />
 </Project>

--- a/Resizetizer/SvgImageResizer.cs
+++ b/Resizetizer/SvgImageResizer.cs
@@ -56,7 +56,7 @@ namespace Resizetizer
 				sourceFile = tempFile;
 			}
 
-			var svg = new SKSvg();
+            var svg = new SkiaSharp.Extended.Svg.SKSvg();
 			svg.Load(sourceFile);
 
 			// Find the actual size of the SVG 
@@ -90,7 +90,7 @@ namespace Resizetizer
 
 			// Export the canvas
 			var img = SKImage.FromBitmap(bmp);
-			var data = img.Encode(SKImageEncodeFormat.Png, 100);
+            var data = img.Encode(SKEncodedImageFormat.Png, 100);
 			using (var fs = File.Open(destinationFile, FileMode.Create)) {
 				data.SaveTo(fs);
 			}

--- a/Resizetizer/packages.config
+++ b/Resizetizer/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="SkiaSharp" version="1.56.1" targetFramework="net45" />
-  <package id="SkiaSharp.Svg" version="1.56.1" targetFramework="net45" />
+  <package id="SkiaSharp" version="1.60.2" targetFramework="net45" />
+  <package id="SkiaSharp.Svg" version="1.60.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net45" />
   <package id="YamlDotNet" version="4.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The old SkiaSharp have an issue with some kind of SVG images (it generate an internal "index out of bounds" exception).
I attach the SVG file that cause me a little headache (this one work with the updated SkiaSharp but not with the old one).

[star_half.svg.zip](https://github.com/Redth/Resizetizer/files/2156545/star_half.svg.zip)

